### PR TITLE
Wire central catalog refresh

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,8 @@
 name: Build
 
 on:
+  schedule:
+    - cron: '07 3 * * 0'
   push:
     branches: [ '*' ]
     tags: [ '*' ]

--- a/.github/workflows/refresh-catalog.yml
+++ b/.github/workflows/refresh-catalog.yml
@@ -1,0 +1,39 @@
+name: Refresh Catalog
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh-catalog:
+    name: Refresh central catalog copy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Refresh catalog
+        run: ./gradlew --no-daemon refreshCatalog
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/refresh-central-catalog
+          delete-branch: true
+          commit-message: Refresh central Gradle version catalog
+          title: Refresh central Gradle version catalog
+          body: |
+            Updates the local Gradle version catalog from NostrGameEngine/libs.catalog.
+
+            If the downloaded catalog is identical to the current file, this workflow exits without opening a pull request.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -455,8 +455,8 @@ packageNativeAll.configure {
 artifacts.add(iosConfiguration.name, packageNativeForIos)
 
 dependencies {
-    annotationProcessor(libs.jniAccessGenerator)
-    compileOnly(libs.jniAccessGenerator)
+    annotationProcessor(libs.jni.access.generator)
+    compileOnly(libs.jni.access.generator)
 
     testImplementation(files(packageNativeForHost))
 }
@@ -548,5 +548,23 @@ val githubActions by tasks.registering(DefaultTask::class) {
     } else {
         logger.lifecycle("Job will only build!")
         dependsOn(tasks.assemble)
+    }
+}
+
+tasks.register("refreshCatalog") {
+    group = "build setup"
+    description = "Downloads the central NostrGameEngine Gradle version catalog."
+
+    val catalogUrl = providers.gradleProperty("centralCatalogUrl")
+        .orElse("https://raw.githubusercontent.com/NostrGameEngine/libs.catalog/main/libs.versions.toml")
+    val outputFile = layout.projectDirectory.file("gradle/libs.versions.toml")
+
+    outputs.file(outputFile)
+
+    doLast {
+        val target = outputFile.asFile
+        target.parentFile.mkdirs()
+        target.writeText(java.net.URI.create(catalogUrl.get()).toURL().readText())
+        println("Refreshed $target")
     }
 }

--- a/conventions/src/main/kotlin/tel.schich.libdatachannel.convention.common.gradle.kts
+++ b/conventions/src/main/kotlin/tel.schich.libdatachannel.convention.common.gradle.kts
@@ -44,9 +44,9 @@ repositories {
 }
 
 dependencies {
-    compileOnly(libs.jdtAnnotations)
+    compileOnly(libs.jdt.annotations)
 
-    testImplementation(libs.junitJupiter)
+    testImplementation(libs.junit.jupiter.engine)
 }
 
 publishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,265 @@
 [versions]
+
+checkstyle = "13.3.0"
+jacoco = "0.8.12"
+lwjgl3 = "3.4.1"
+angle = "2026-05-09"
+androidGradlePlugin = "9.1.1"
+androidGradlePluginTemplate = "8.12.2"
+androidxJunit = "1.3.0"
+androidxTestCore = "1.7.0"
+androidxTestRunner = "1.7.0"
+appcompat = "1.7.1"
+asm = "9.9"
+bcprov = "1.84"
+bech32 = "1.2.1"
+bech32-snapshot = "1.0.0-SNAPSHOT"
+bolt11 = "0.0.1"
+bolt11-snapshot = "0.0.0-SNAPSHOT"
+chicory = "1.7.5-nge2"
+commons-math3 = "3.6.1"
+constraintlayout = "2.2.1"
 dockcrossPlugin = "0.4.3"
-jniAccessGenerator = "1.2.2"
+espressoCore = "3.7.0"
+findsecbugs = "1.12.0"
+foojayResolver = "1.0.0"
+gradleNexusPublish = "2.0.0"
+gradleTestRetry = "1.6.4"
+graalvmNativePlugin = "0.11.5"
+guava = "33.3.1-jre"
+imagewebp = "1.3.0"
+imagewebp-snapshot = "0.1.0-SNAPSHOT"
+jackson = "2.17.2"
+jakartaAnnotation = "2.1.1"
 jdtAnnotations = "2.4.100"
+jniAccessGenerator = "1.2.2"
+junit4Version = "4.13.2"
 junitJupiter = "5.10.2"
+kotlin = "2.1.20"
+libjglios = "0.6"
+libjglios-snapshot = "0.3-SNAPSHOT"
+libdatachannelJava = "0.24.1.nge5"
+libdatachannelJava-snapshot = "0.24.1.0-SNAPSHOT"
+lnurl4j = "0.0.4"
+lnurl4j-snapshot = "0.3.0-SNAPSHOT"
+material = "1.12.0"
 mavenDeployer = "0.5.2"
+navigationFragment = "2.6.0"
+navigationUi = "2.6.0"
+nanosvgChicoryJava = "0.1"
+nanosvgChicoryJava-snapshot = "0.1.0-SNAPSHOT"
+ngengine = "0.2.0"
+ngengine-snapshot = "0.3.0-SNAPSHOT"
+ngePlatform = "0.2.3"
+ngePlatform-snapshot = "0.3.0-SNAPSHOT"
+saferalloc = "0.0.10"
+saferalloc-snapshot = "0.1.0-SNAPSHOT"
+nifty = "1.4.3"
+nostr4j = "0.3.0"
+nostr4j-snapshot = "0.3.0-SNAPSHOT"
+nostrads = "0.2.4"
+nostrads-snapshot = "0.2.0-SNAPSHOT"
+okhttp = "5.3.2"
+prettier = "2.8.8"
+prettierJava = "2.2.0"
+spotbugs = "4.9.8"
+spotbugsPlugin = "6.5.5"
+spotlessPlugin = "8.4.0"
+slf4j = "2.0.12"
+stbImage = "2.30.5"
+stbImage-snapshot = "1.0.0-SNAPSHOT"
+teavm = "0.13.0"
+wasm2class = "0.5.0"
+jmeAndroidNatives = "3.10.0-xt16kb-alloc"
 
 [libraries]
-jniAccessGenerator = { module = "tel.schich:jni-access-generator", version.ref = "jniAccessGenerator" }
-jdtAnnotations = { module = "org.eclipse.jdt:org.eclipse.jdt.annotation", version.ref = "jdtAnnotations" }
-junitJupiter = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
+
+androidx-annotation = "androidx.annotation:annotation:1.10.0"
+androidx-fragment = "androidx.fragment:fragment:1.8.9"
+androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.7.0"
+android-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
+android-build-gradle-template = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePluginTemplate" }
+android-support-appcompat = "com.android.support:appcompat-v7:28.0.0"
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
+appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
+asm-tree = { module = "org.ow2.asm:asm-tree", version.ref = "asm" }
+bcprov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bcprov" }
+commons-math3 = { module = "org.apache.commons:commons-math3", version.ref = "commons-math3" }
+constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espressoCore" }
+ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxJunit" }
+findsecbugs-plugin = { module = "com.h3xstream.findsecbugs:findsecbugs-plugin", version.ref = "findsecbugs" }
+groovy-test = "org.apache.groovy:groovy-test:4.0.31"
+gson = "com.google.code.gson:gson:2.14.0"
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+j-ogg-vorbis = "com.github.stephengold:j-ogg-vorbis:1.0.6"
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakartaAnnotation" }
+jdt-annotations = { module = "org.eclipse.jdt:org.eclipse.jdt.annotation", version.ref = "jdtAnnotations" }
+jni-access-generator = { module = "tel.schich:jni-access-generator", version.ref = "jniAccessGenerator" }
+jme3-android-natives = { module = "org.jmonkeyengine:jme3-android-native", version.ref = "jmeAndroidNatives" }
+jbullet = "com.github.stephengold:jbullet:1.0.3"
+jinput = "net.java.jinput:jinput:2.0.9"
+jna = "net.java.dev.jna:jna:5.18.1"
+jnaerator-runtime = "com.nativelibs4java:jnaerator-runtime:0.12"
+junit-bom = "org.junit:junit-bom:5.13.4"
+junit = { module = "junit:junit", version.ref = "junit4Version" }
+junit4 = "junit:junit:4.13.2"
+junit4-ref = { module = "junit:junit", version.ref = "junit4Version" }
+junit-v4133snapshot = { module = "junit:junit", version.ref = "junit4Version" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+lwjgl2 = "org.jmonkeyengine:lwjgl:2.9.5"
+lwjgl3-awt = "org.jmonkeyengine:lwjgl3-awt:0.2.4"
+
+lwjgl3-base     = { module = "org.lwjgl:lwjgl",          version.ref = "lwjgl3" }
+lwjgl3-glfw     = { module = "org.lwjgl:lwjgl-glfw",     version.ref = "lwjgl3" }
+lwjgl3-jawt     = { module = "org.lwjgl:lwjgl-jawt",     version.ref = "lwjgl3" }
+lwjgl3-jemalloc = { module = "org.lwjgl:lwjgl-jemalloc", version.ref = "lwjgl3" }
+lwjgl3-openal   = { module = "org.lwjgl:lwjgl-openal",   version.ref = "lwjgl3" }
+lwjgl3-opengl   = { module = "org.lwjgl:lwjgl-opengl",   version.ref = "lwjgl3" }
+lwjgl3-stb      = { module = "org.lwjgl:lwjgl-stb",      version.ref = "lwjgl3" }
+lwjgl3-nanovg   = { module = "org.lwjgl:lwjgl-nanovg",   version.ref = "lwjgl3" }
+lwjgl3-sdl      = { module = "org.lwjgl:lwjgl-sdl",      version.ref = "lwjgl3" }
+lwjgl3-opengles = { module = "org.lwjgl:lwjgl-opengles", version.ref = "lwjgl3" }
+lwjgl3-egl   = { module = "org.lwjgl:lwjgl-egl", version.ref = "lwjgl3" }
+
+mokito-core = "org.mockito:mockito-core:5.23.0"
+mokito-junit-jupiter = "org.mockito:mockito-junit-jupiter:5.23.0"
+
+nifty                  = { module = "com.github.nifty-gui:nifty",                  version.ref = "nifty" }
+nifty-default-controls = { module = "com.github.nifty-gui:nifty-default-controls", version.ref = "nifty" }
+nifty-examples         = { module = "com.github.nifty-gui:nifty-examples",         version.ref = "nifty" }
+nifty-style-black      = { module = "com.github.nifty-gui:nifty-style-black",      version.ref = "nifty" }
+
+spotbugs-gradle-plugin = "com.github.spotbugs.snom:spotbugs-gradle-plugin:6.4.8"
+vecmath = "javax.vecmath:vecmath:1.5.2"
+
+material = { module = "com.google.android.material:material", version.ref = "material" }
+navigation-fragment = { module = "androidx.navigation:navigation-fragment", version.ref = "navigationFragment" }
+navigation-ui = { module = "androidx.navigation:navigation-ui", version.ref = "navigationUi" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+slf4j-jdk14 = { module = "org.slf4j:slf4j-jdk14", version.ref = "slf4j" }
+teavm-jso = { module = "org.teavm:teavm-jso", version.ref = "teavm" }
+teavm-jso-apis = { module = "org.teavm:teavm-jso-apis", version.ref = "teavm" }
+
+angle = { module = "org.ngengine:angle-natives", version.ref = "angle" }
+bech32 = { module = "org.ngengine:bech32", version.ref = "bech32" }
+bech32-snapshot = { module = "org.ngengine:bech32", version.ref = "bech32-snapshot" }
+bolt11 = { module = "org.ngengine:bolt11", version.ref = "bolt11" }
+bolt11-snapshot = { module = "org.ngengine:bolt11", version.ref = "bolt11-snapshot" }
+chicory-runtime = { module = "org.ngengine.chicory:runtime", version.ref = "chicory" }
+chicory-wasm = { module = "org.ngengine.chicory:wasm", version.ref = "chicory" }
+imagewebp = { module = "org.ngengine:image-webp-decoder", version.ref = "imagewebp" }
+imagewebp-snapshot = { module = "org.ngengine:image-webp-decoder", version.ref = "imagewebp-snapshot" }
+jme3-core = { module = "org.ngengine:jme3-core", version.ref = "ngengine" }
+jme3-core-snapshot = { module = "org.ngengine:jme3-core", version.ref = "ngengine-snapshot" }
+jme3-desktop = { module = "org.ngengine:jme3-desktop", version.ref = "ngengine" }
+jme3-desktop-snapshot = { module = "org.ngengine:jme3-desktop", version.ref = "ngengine-snapshot" }
+jme3-effects = { module = "org.ngengine:jme3-effects", version.ref = "ngengine" }
+jme3-effects-snapshot = { module = "org.ngengine:jme3-effects", version.ref = "ngengine-snapshot" }
+jme3-ios = { module = "org.ngengine:jme3-ios", version.ref = "ngengine" }
+jme3-ios-snapshot = { module = "org.ngengine:jme3-ios", version.ref = "ngengine-snapshot" }
+jme3-lwjgl3 = { module = "org.ngengine:jme3-lwjgl3", version.ref = "ngengine" }
+jme3-lwjgl3-snapshot = { module = "org.ngengine:jme3-lwjgl3", version.ref = "ngengine-snapshot" }
+jme3-networking = { module = "org.ngengine:jme3-networking", version.ref = "ngengine" }
+jme3-networking-snapshot = { module = "org.ngengine:jme3-networking", version.ref = "ngengine-snapshot" }
+jme3-plugins = { module = "org.ngengine:jme3-plugins", version.ref = "ngengine" }
+jme3-plugins-snapshot = { module = "org.ngengine:jme3-plugins", version.ref = "ngengine-snapshot" }
+jme3-plugins-json = { module = "org.ngengine:jme3-plugins-json", version.ref = "ngengine" }
+jme3-plugins-json-snapshot = { module = "org.ngengine:jme3-plugins-json", version.ref = "ngengine-snapshot" }
+jme3-plugins-json-gson = { module = "org.ngengine:jme3-plugins-json-gson", version.ref = "ngengine" }
+jme3-plugins-json-gson-snapshot = { module = "org.ngengine:jme3-plugins-json-gson", version.ref = "ngengine-snapshot" }
+jme3-terrain = { module = "org.ngengine:jme3-terrain", version.ref = "ngengine" }
+jme3-terrain-snapshot = { module = "org.ngengine:jme3-terrain", version.ref = "ngengine-snapshot" }
+libdatachannel-java = { module = "org.ngengine:libdatachannel-java", version.ref = "libdatachannelJava" }
+libdatachannel-java-snapshot = { module = "org.ngengine:libdatachannel-java", version.ref = "libdatachannelJava-snapshot" }
+libdatachannel-java-android = { module = "org.ngengine:libdatachannel-java-android", version.ref = "libdatachannelJava" }
+libdatachannel-java-android-snapshot = { module = "org.ngengine:libdatachannel-java-android", version.ref = "libdatachannelJava-snapshot" }
+libdatachannel-java-arch-detect = { module = "org.ngengine:libdatachannel-java-arch-detect", version.ref = "libdatachannelJava" }
+libdatachannel-java-arch-detect-snapshot = { module = "org.ngengine:libdatachannel-java-arch-detect", version.ref = "libdatachannelJava-snapshot" }
+libdatachannel-java-ios = { module = "org.ngengine:libdatachannel-java-ios", version.ref = "libdatachannelJava" }
+libdatachannel-java-ios-snapshot = { module = "org.ngengine:libdatachannel-java-ios", version.ref = "libdatachannelJava-snapshot" }
+libjglios-angle-ios = { module = "org.ngengine:libjglios-angle-ios", version.ref = "libjglios" }
+libjglios-angle-ios-snapshot = { module = "org.ngengine:libjglios-angle-ios", version.ref = "libjglios-snapshot" }
+libjglios-core-ios = { module = "org.ngengine:libjglios-core-ios", version.ref = "libjglios" }
+libjglios-core-ios-snapshot = { module = "org.ngengine:libjglios-core-ios", version.ref = "libjglios-snapshot" }
+libjglios-gles-ios = { module = "org.ngengine:libjglios-gles-ios", version.ref = "libjglios" }
+libjglios-gles-ios-snapshot = { module = "org.ngengine:libjglios-gles-ios", version.ref = "libjglios-snapshot" }
+libjglios-gradle-plugin = { module = "org.ngengine:libjglios-gradle-plugin", version.ref = "libjglios" }
+libjglios-gradle-plugin-snapshot = { module = "org.ngengine:libjglios-gradle-plugin", version.ref = "libjglios-snapshot" }
+libjglios-openal-ios = { module = "org.ngengine:libjglios-openal-ios", version.ref = "libjglios" }
+libjglios-openal-ios-snapshot = { module = "org.ngengine:libjglios-openal-ios", version.ref = "libjglios-snapshot" }
+libjglios-sdl3-ios = { module = "org.ngengine:libjglios-sdl3-ios", version.ref = "libjglios" }
+libjglios-sdl3-ios-snapshot = { module = "org.ngengine:libjglios-sdl3-ios", version.ref = "libjglios-snapshot" }
+lnurl4j = { module = "org.ngengine:lnurl4j", version.ref = "lnurl4j" }
+lnurl4j-snapshot = { module = "org.ngengine:lnurl4j", version.ref = "lnurl4j-snapshot" }
+nanosvg-chicory-java = { module = "org.ngengine:nanosvg-chicory-java", version.ref = "nanosvgChicoryJava" }
+nanosvg-chicory-java-snapshot = { module = "org.ngengine:nanosvg-chicory-java", version.ref = "nanosvgChicoryJava-snapshot" }
+nge-auth = { module = "org.ngengine:nge-auth", version.ref = "ngengine" }
+nge-auth-snapshot = { module = "org.ngengine:nge-auth", version.ref = "ngengine-snapshot" }
+nge-core = { module = "org.ngengine:nge-core", version.ref = "ngengine" }
+nge-core-snapshot = { module = "org.ngengine:nge-core", version.ref = "ngengine-snapshot" }
+nge-gui = { module = "org.ngengine:nge-gui", version.ref = "ngengine" }
+nge-gui-snapshot = { module = "org.ngengine:nge-gui", version.ref = "ngengine-snapshot" }
+nge-networking = { module = "org.ngengine:nge-networking", version.ref = "ngengine" }
+nge-networking-snapshot = { module = "org.ngengine:nge-networking", version.ref = "ngengine-snapshot" }
+nge-platform-android = { module = "org.ngengine:nge-platform-android", version.ref = "ngePlatform" }
+nge-platform-android-snapshot = { module = "org.ngengine:nge-platform-android", version.ref = "ngePlatform-snapshot" }
+nge-platform-common = { module = "org.ngengine:nge-platform-common", version.ref = "ngePlatform" }
+nge-platform-common-snapshot = { module = "org.ngengine:nge-platform-common", version.ref = "ngePlatform-snapshot" }
+nge-platform-jvm = { module = "org.ngengine:nge-platform-jvm", version.ref = "ngePlatform" }
+nge-platform-jvm-snapshot = { module = "org.ngengine:nge-platform-jvm", version.ref = "ngePlatform-snapshot" }
+nge-platform-teavm = { module = "org.ngengine:nge-platform-teavm", version.ref = "ngePlatform" }
+nge-platform-teavm-snapshot = { module = "org.ngengine:nge-platform-teavm", version.ref = "ngePlatform-snapshot" }
+nostr4j = { module = "org.ngengine:nostr4j", version.ref = "nostr4j" }
+nostr4j-snapshot = { module = "org.ngengine:nostr4j", version.ref = "nostr4j-snapshot" }
+nostr4j-turn-server = { module = "org.ngengine:nostr4j-turn-server", version.ref = "nostr4j" }
+nostr4j-turn-server-snapshot = { module = "org.ngengine:nostr4j-turn-server", version.ref = "nostr4j-snapshot" }
+nostrads = { module = "org.ngengine:nostrads", version.ref = "nostrads" }
+nostrads-snapshot = { module = "org.ngengine:nostrads", version.ref = "nostrads-snapshot" }
+saferalloc = { module = "org.ngengine:saferalloc", version.ref = "saferalloc" }
+saferalloc-snapshot = { module = "org.ngengine:saferalloc", version.ref = "saferalloc-snapshot" }
+saferalloc-natives-linux-x8664 = { module = "org.ngengine:saferalloc-natives-linux-x86_64", version.ref = "saferalloc" }
+saferalloc-natives-linux-x8664-snapshot = { module = "org.ngengine:saferalloc-natives-linux-x86_64", version.ref = "saferalloc-snapshot" }
+saferalloc-natives-linux-aarch64 = { module = "org.ngengine:saferalloc-natives-linux-aarch64", version.ref = "saferalloc" }
+saferalloc-natives-linux-aarch64-snapshot = { module = "org.ngengine:saferalloc-natives-linux-aarch64", version.ref = "saferalloc-snapshot" }
+saferalloc-natives-windows-x8664 = { module = "org.ngengine:saferalloc-natives-windows-x86_64", version.ref = "saferalloc" }
+saferalloc-natives-windows-x8664-snapshot = { module = "org.ngengine:saferalloc-natives-windows-x86_64", version.ref = "saferalloc-snapshot" }
+saferalloc-natives-windows-aarch64 = { module = "org.ngengine:saferalloc-natives-windows-aarch64", version.ref = "saferalloc" }
+saferalloc-natives-windows-aarch64-snapshot = { module = "org.ngengine:saferalloc-natives-windows-aarch64", version.ref = "saferalloc-snapshot" }
+saferalloc-natives-macos-x8664 = { module = "org.ngengine:saferalloc-natives-macos-x86_64", version.ref = "saferalloc" }
+saferalloc-natives-macos-x8664-snapshot = { module = "org.ngengine:saferalloc-natives-macos-x86_64", version.ref = "saferalloc-snapshot" }
+saferalloc-natives-macos-aarch64 = { module = "org.ngengine:saferalloc-natives-macos-aarch64", version.ref = "saferalloc" }
+saferalloc-natives-macos-aarch64-snapshot = { module = "org.ngengine:saferalloc-natives-macos-aarch64", version.ref = "saferalloc-snapshot" }
+saferalloc-natives-android = { module = "org.ngengine:saferalloc-natives-android", version.ref = "saferalloc" }
+saferalloc-natives-android-snapshot = { module = "org.ngengine:saferalloc-natives-android", version.ref = "saferalloc-snapshot" }
+saferalloc-natives-ios = { module = "org.ngengine:saferalloc-natives-ios", version.ref = "saferalloc" }
+saferalloc-natives-ios-snapshot = { module = "org.ngengine:saferalloc-natives-ios", version.ref = "saferalloc-snapshot" }
+stb-image = { module = "org.ngengine:stb-image", version.ref = "stbImage" }
+stb-image-snapshot = { module = "org.ngengine:stb-image", version.ref = "stbImage-snapshot" }
+
+[bundles]
+saferalloc = ["saferalloc", "saferalloc-natives-linux-x8664", "saferalloc-natives-linux-aarch64", "saferalloc-natives-windows-x8664", "saferalloc-natives-windows-aarch64", "saferalloc-natives-macos-x8664", "saferalloc-natives-macos-aarch64", "saferalloc-natives-android"]
 
 [plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePluginTemplate" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePluginTemplate" }
 dockcross = { id = "tel.schich.dockcross", version.ref = "dockcrossPlugin" }
+foojay-resolver = { id = "org.gradle.toolchains.foojay-resolver-convention", version.ref = "foojayResolver" }
+gradle-nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublish" }
+graalvm-native = { id = "org.graalvm.buildtools.native", version.ref = "graalvmNativePlugin" }
+jacoco = { id = "jacoco", version.ref = "jacoco" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 mavenDeployer = { id = "io.github.danielliu1123.deployer", version.ref = "mavenDeployer" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradleNexusPublish" }
+spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugsPlugin" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }
+teavm = { id = "org.teavm", version.ref = "teavm" }
+test-retry = { id = "org.gradle.test-retry", version.ref = "gradleTestRetry" }
+wasm2class = { id = "at.released.wasm2class.plugin", version.ref = "wasm2class" }


### PR DESCRIPTION
## Summary
- Replace the local Gradle version catalog with the centralized NostrGameEngine catalog.
- Add a `refreshCatalog` Gradle task that downloads `NostrGameEngine/libs.catalog`.
- Add a manual `refresh-catalog.yml` workflow that opens a PR only when the refreshed catalog changes.
- Add or update the existing snapshot publishing workflow schedule where this repository publishes snapshots.

## Verification
- Parsed all updated TOML catalogs with `tomllib`.
- Parsed updated workflow YAML with Ruby `YAML.load_file`.
- Ran `./gradlew --no-daemon -q refreshCatalog` successfully in `bech32` as the representative Groovy Gradle task.

Note: local Kotlin-task execution in `cap-cache-generator` was blocked before task execution because the machine ran out of disk space while the Gradle wrapper tried to install Gradle 8.4.
